### PR TITLE
fix(icon-picker): 解决icon-picker组件切换分页后，关键词检索失效问题

### DIFF
--- a/packages/effects/common-ui/src/components/icon-picker/icon-picker.vue
+++ b/packages/effects/common-ui/src/components/icon-picker/icon-picker.vue
@@ -76,6 +76,12 @@ const keyword = ref('');
 const keywordDebounce = refDebounced(keyword, 300);
 const innerIcons = ref<string[]>([]);
 
+/* 当检索关键词变化时，重置分页 */
+watch(keywordDebounce, () => {
+  currentPage.value = 1;
+  setCurrentPage(1);
+});
+
 watchDebounced(
   () => props.prefix,
   async (prefix) => {


### PR DESCRIPTION
当icon-picker组件切换分页后，在输入关键词检索，但是分页没有重置，导致检索结果异常